### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fernforestgames/godot-savekit/security/code-scanning/1](https://github.com/fernforestgames/godot-savekit/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so it applies to all jobs unless overridden. For this workflow, the minimal safe setting is:

- `contents: read`

This supports `actions/checkout` and keeps token scope restricted. No other permissions are required based on the shown steps (download/unzip/run tests).  
Edit `.github/workflows/main.yml` by inserting the block after the trigger section (`on: ...`) and before `jobs:`. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
